### PR TITLE
Initial implementation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2018 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ module "blog_service" {
 
 **Got a question?**
 
-File a GitHub [issue](https://github.com/cloudposse/default-backend/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Slack](https://slack.cloudposse.com).
+File a GitHub [issue](https://github.com/cloudposse/terraform-aws-alb-ingress/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Slack](https://slack.cloudposse.com).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-``![Cloud Posse](https://cloudposse.com/logo-300x69.png)
+![Cloud Posse](https://cloudposse.com/logo-300x69.png)
 
 # terraform-aws-alb-ingress [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-alb-ingress.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-alb-ingress) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ module "blog_service" {
 | `port`                             |     `80`        | The port for generated ALB target group (if target_group_arn not set)            |    No    |
 | `protocol`                         |    `HTTP`       | The protocol for generated ALB target group (if target_group_arn not set)        |    No    |
 | `vpc_id`                           |      ``         | The VPC ID where generated ALB target group (if target_group_arn not set)        |    No    |
-| `paths`                            |   `["/*"]`      | Path pattern to match (a maximum of 1 can be defined)                            |    No    |
+| `paths`                            |     `[]`        | Path pattern to match (a maximum of 1 can be defined)                            |    No    |
+| `hosts`                            |     `[]`        | Hosts to match in Hosts header                                                   |    No    |
 | `attributes`                       |     `[]`        | Additional attributes (e.g. `1`)                                                 |    No    |
 | `tags`                             |     `{}`        | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                               |    No    |
 | `delimiter`                        |     `-`         | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`       |    No    |

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# terraform-aws-alb-ingress
+``![Cloud Posse](https://cloudposse.com/logo-300x69.png)
 
-Terraform module to provision an HTTP style ingress based on hostname and path
+# terraform-aws-alb-ingress [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-alb-ingress.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-alb-ingress) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
+A Terraform module to provision an HTTP style ingress based on hostname and path.
 
-Usage Example
+## Usage
 
 ```
 module "alb" {
@@ -15,25 +16,25 @@ module "alb" {
 }
 
 module "api_ingress" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=master"
-  namespace  = "eg"
-  stage      = "dev"
-  name       = "web"
-  attributes = "api"
-  vpc_id     = "..."
-  target_group_arn = "${module.alb.default_target_group_arn}"
-  paths      = ["/api/*"]
+  source            = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=master"
+  namespace         = "eg"
+  stage             = "dev"
+  name              = "web"
+  attributes        = "api"
+  vpc_id            = "..."
+  target_group_arn  = "${module.alb.default_target_group_arn}"
+  paths             = ["/api/*"]
 }
 
 module "blog_ingress" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=master"
-  namespace  = "eg"
-  stage      = "dev"
-  name       = "web"
-  attributes = "blog"
-  vpc_id     = "..."
-  target_group_arn = "${module.alb.default_target_group_arn}"
-  paths      = ["/blog/*"]
+  source            = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=master"
+  namespace         = "eg"
+  stage             = "dev"
+  name              = "web"
+  attributes        = "blog"
+  vpc_id            = "..."
+  target_group_arn  = "${module.alb.default_target_group_arn}"
+  paths             = ["/blog/*"]
 }
 
 module "blog_service" {
@@ -50,5 +51,120 @@ module "blog_service" {
   security_group_ids        = ["${module.vpc.vpc_default_security_group_id}"]
   private_subnet_ids        = "${module.dynamic_subnets.private_subnet_ids}"
 }
-
 ```
+
+## Inputs
+
+| Name                               |    Default      | Description                                                                      | Required |
+|:-----------------------------------|:---------------:|:---------------------------------------------------------------------------------|:--------:|
+| `namespace`                        |      ``         | Namespace (e.g. `cp` or `cloudposse`)                                            |   Yes    |
+| `stage`                            |      ``         | Stage (e.g. `prod`, `dev`, `staging`)                                            |   Yes    |
+| `name`                             |      ``         | Name  (e.g. `app` or `cluster`)                                                  |   Yes    |
+| `target_group_arn`                 |      ``         | ALB target group ARN, if this is an empty string a new one will be generated     |    No    |
+| `listener_arns`                    |     `[]`        | A list of ALB listener ARNs to attach ALB listener rule to                       |    No    |
+| `deregistration_delay`             |     `15`        | The amount of time to wait in seconds while deregistering target                 |    No    |
+| `health_check_path`                |     `/`         | The destination for the health check request                                     |    No    |
+| `health_check_timeout`             |     `10`        | The amount of time to wait in seconds before failing a health check request      |    No    |
+| `health_check_healthy_threshold`   |     `2`         | The number of consecutive health checks successes required before healthy        |    No    |
+| `health_check_unhealthy_threshold` |     `2`         | The number of consecutive health check failures required before unhealthy        |    No    |
+| `health_check_interval`            |     `15`        | The duration in seconds in between health checks                                 |    No    |
+| `health_check_matcher`             |   `200-399`     | The HTTP response codes to indicate a healthy check                              |    No    |
+| `priority`                         |     `100`       | The priority for the rule between 1 and 50000 (1 being highest priority)         |    No    |
+| `port`                             |     `80`        | The port for generated ALB target group (if target_group_arn not set)            |    No    |
+| `protocol`                         |    `HTTP`       | The protocol for generated ALB target group (if target_group_arn not set)        |    No    |
+| `vpc_id`                           |      ``         | The VPC ID where generated ALB target group (if target_group_arn not set)        |    No    |
+| `paths`                            |   `["/*"]`      | Path pattern to match (a maximum of 1 can be defined)                            |    No    |
+| `attributes`                       |     `[]`        | Additional attributes (e.g. `1`)                                                 |    No    |
+| `tags`                             |     `{}`        | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                               |    No    |
+| `delimiter`                        |     `-`         | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`       |    No    |
+
+
+
+## Outputs
+
+| Name                            | Description                                                     |
+|:--------------------------------|:----------------------------------------------------------------|
+| `target_group_arn`              | The target group ARN                                            |
+
+
+## Help
+
+**Got a question?**
+
+File a GitHub [issue](https://github.com/cloudposse/default-backend/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Slack](https://slack.cloudposse.com).
+
+## Contributing
+
+### Bug Reports & Feature Requests
+
+Please use the [issue tracker](https://github.com/cloudposse/terraform-aws-alb-ingress/issues) to report any bugs or file feature requests.
+
+### Developing
+
+If you are interested in being a contributor and want to get involved in developing `terraform-aws-alb-ingress`, we would love to hear from you! Shoot us an [email](mailto:hello@cloudposse.com).
+
+In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
+
+ 1. **Fork** the repo on GitHub
+ 2. **Clone** the project to your own machine
+ 3. **Commit** changes to your own branch
+ 4. **Push** your work back up to your fork
+ 5. Submit a **Pull request** so that we can review your changes
+
+**NOTE:** Be sure to merge the latest from "upstream" before making a pull request!
+
+## License
+
+[APACHE 2.0](LICENSE) © 2018 [Cloud Posse, LLC](https://cloudposse.com)
+
+See [LICENSE](LICENSE) for full details.
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+## About
+
+This project is maintained and funded by [Cloud Posse, LLC][website].
+
+![Cloud Posse](https://cloudposse.com/logo-300x69.png)
+
+
+Like it? Please let us know at <hello@cloudposse.com>
+
+We love [Open Source Software](https://github.com/cloudposse/)!
+
+See [our other projects][community]
+or [hire us][hire] to help build your next cloud platform.
+
+  [website]: https://cloudposse.com/
+  [community]: https://github.com/cloudposse/
+  [hire]: https://cloudposse.com/contact/
+
+
+## Contributors
+
+| [![Erik Osterman][erik_img]][erik_web]<br/>[Erik Osterman][erik_web] | [![Andriy Knysh][andriy_img]][andriy_web]<br/>[Andriy Knysh][andriy_web] |[![Igor Rodionov][igor_img]][igor_web]<br/>[Igor Rodionov][igor_img]|[![Sarkis Varozian][sarkis_img]][sarkis_web]<br/>[Sarkis Varozian][sarkis_web] |
+|-------------------------------------------------------|------------------------------------------------------------------|------------------------------------------------------------------|------------------------------------------------------------------|
+
+[erik_img]: http://s.gravatar.com/avatar/88c480d4f73b813904e00a5695a454cb?s=144
+[erik_web]: https://github.com/osterman/
+[andriy_img]: https://avatars0.githubusercontent.com/u/7356997?v=4&u=ed9ce1c9151d552d985bdf5546772e14ef7ab617&s=144
+[andriy_web]: https://github.com/aknysh/
+[igor_img]: http://s.gravatar.com/avatar/bc70834d32ed4517568a1feb0b9be7e2?s=144
+[igor_web]: https://github.com/goruha/
+[sarkis_img]: https://avatars3.githubusercontent.com/u/42673?s=144&v=4
+[sarkis_web]: https://github.com/sarkis/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # terraform-aws-alb-ingress
+
 Terraform module to provision an HTTP style ingress based on hostname and path
+
+
+Usage Example
+
+```
+module "alb" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=master"
+  namespace  = "eg"
+  stage      = "dev"
+  name       = "web"
+  vpc_id     = "..."
+}
+
+module "api_ingress" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=master"
+  namespace  = "eg"
+  stage      = "dev"
+  name       = "web"
+  attributes = "api"
+  vpc_id     = "..."
+  target_group_arn = "${module.alb.default_target_group_arn}"
+  paths      = ["/api/*"]
+}
+
+module "blog_ingress" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=master"
+  namespace  = "eg"
+  stage      = "dev"
+  name       = "web"
+  attributes = "blog"
+  vpc_id     = "..."
+  target_group_arn = "${module.alb.default_target_group_arn}"
+  paths      = ["/blog/*"]
+}
+
+module "blog_service" {
+  source                    = "git::https://github.com/cloudposse/terraform-aws-ecs-alb-service-task.git?ref=0.1.0"
+  namespace                 = "eg"
+  stage                     = "dev"
+  name                      = "blog"
+  alb_target_group_arn      = "${module.alb.default_target_group.arn}"
+  container_definition_json = "${module.container_definition.json}"
+  ecr_repository_name       = "${module.ecr.repository_name}"
+  ecs_cluster_arn           = "${aws_ecs_cluster.default.arn}"
+  launch_type               = "FARGATE"
+  vpc_id                    = "${module.vpc.vpc_id}"
+  security_group_ids        = ["${module.vpc.vpc_default_security_group_id}"]
+  private_subnet_ids        = "${module.dynamic_subnets.private_subnet_ids}"
+}
+
+```

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,17 @@ resource "aws_lb_target_group" "default" {
   vpc_id      = "${var.vpc_id}"
   target_type = "${var.target_type}"
 
+  deregistration_delay = "${var.deregistration_delay}"
+
+  health_check {
+    path                = "${var.health_check_path}"
+    timeout             = "${var.health_check_timeout}"
+    healthy_threshold   = "${var.health_check_healthy_threshold}"
+    unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
+    interval            = "${var.health_check_interval}"
+    matcher             = "${var.health_check_matcher}"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 locals {
   generate_target_group_arn = "${var.target_group_arn == "" ? 1 : 0}"
-  num_listeners = "${length(var.listener_arns)}"
 }
 
 locals {
@@ -44,7 +43,7 @@ resource "aws_lb_target_group" "default" {
 }
 
 resource "aws_lb_listener_rule" "default" {
-  count        = "${local.num_listeners}"
+  count        = "${length(var.listener_arns)}"
   listener_arn = "${var.listener_arns[count.index]}"
   priority     = "${var.priority+var.listener_arns[count.index]}"
 

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "aws_lb_target_group" "default" {
 }
 
 resource "aws_lb_listener_rule" "paths" {
-  count        = "${coalescelist(var.paths, var.hosts) == var.hosts ? length(var.listener_arns) : 0}"
+  count        = "${length(var.paths) > 0 && length(var.hosts) == 0 ? length(var.listener_arns) : 0}"
   listener_arn = "${var.listener_arns[count.index]}"
   priority     = "${var.priority + count.index}"
 
@@ -58,7 +58,7 @@ resource "aws_lb_listener_rule" "paths" {
 }
 
 resource "aws_lb_listener_rule" "hosts" {
-  count        = "${coalescelist(var.paths, var.hosts) == var.paths ? length(var.listener_arns) : 0}"
+  count        = "${length(var.hosts) > 0 && length(var.paths) == 0 ? length(var.listener_arns) : 0}"
   listener_arn = "${var.listener_arns[count.index]}"
   priority     = "${var.priority + count.index}"
 
@@ -74,7 +74,7 @@ resource "aws_lb_listener_rule" "hosts" {
 }
 
 resource "aws_lb_listener_rule" "hosts_paths" {
-  count        = "${coalescelist(var.paths, var.hosts) == false ? length(var.listener_arns) : 0}"
+  count        = "${length(var.paths) > 0 && length(var.hosts) > 0 ? length(var.listener_arns) : 0}"
   listener_arn = "${var.listener_arns[count.index]}"
   priority     = "${var.priority + count.index}"
 

--- a/main.tf
+++ b/main.tf
@@ -52,10 +52,10 @@ resource "aws_lb_listener_rule" "default" {
     target_group_arn = "${local.target_group_arn}"
   }
 
-  condition {
-    field  = "host-header"
-    values = ["${var.hosts}"]
-  }
+//  condition {
+//    field  = "host-header"
+//    values = ["${var.hosts}"]
+//  }
 
   condition {
     field  = "path-pattern"

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "default_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.3.5"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.3"
   enabled    = "${local.generate_target_group_arn}"
   attributes = "${var.attributes}"
   delimiter  = "${var.delimiter}"

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "aws_lb_target_group" "default" {
 }
 
 resource "aws_lb_listener_rule" "default" {
-  count        = "${count(var.listener_arns)}"
+  count        = "${length(var.listener_arns)}"
   listener_arn = "${var.listener_arns[count.index]}"
   priority     = "${var.priority+var.listener_arns[count.index]}"
 

--- a/main.tf
+++ b/main.tf
@@ -52,11 +52,6 @@ resource "aws_lb_listener_rule" "default" {
     target_group_arn = "${local.target_group_arn}"
   }
 
-//  condition {
-//    field  = "host-header"
-//    values = ["${var.hosts}"]
-//  }
-
   condition {
     field  = "path-pattern"
     values = ["${var.paths}"]

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "aws_lb_target_group" "default" {
 }
 
 resource "aws_lb_listener_rule" "default" {
-  count        = "${length(var.listener_arns)}"
+  count        = "1"
   listener_arn = "${var.listener_arns[count.index]}"
   priority     = "${var.priority + count.index}"
 

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "aws_lb_target_group" "default" {
 resource "aws_lb_listener_rule" "default" {
   count        = "${length(var.listener_arns)}"
   listener_arn = "${var.listener_arns[count.index]}"
-  priority     = "${var.priority+var.listener_arns[count.index]}"
+  priority     = "${var.priority + count.index}"
 
   action {
     type             = "forward"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,10 @@
 locals {
   generate_target_group_arn = "${var.target_group_arn == "" ? 1 : 0}"
+  num_listeners = "${length(var.listener_arns)}"
+}
+
+locals {
+  target_group_arn = "${local.generate_target_group_arn ? aws_lb_target_group.default.arn : var.target_group_arn}"
 }
 
 module "default_label" {
@@ -13,9 +18,6 @@ module "default_label" {
   tags       = "${var.tags}"
 }
 
-locals {
-  target_group_arn = "${local.generate_target_group_arn ? aws_lb_target_group.default.arn : var.target_group_arn}"
-}
 
 resource "aws_lb_target_group" "default" {
   count       = "${local.generate_target_group_arn}"
@@ -42,7 +44,7 @@ resource "aws_lb_target_group" "default" {
 }
 
 resource "aws_lb_listener_rule" "default" {
-  count        = "${length(var.listener_arns)}"
+  count        = "${local.num_listeners}"
   listener_arn = "${var.listener_arns[count.index]}"
   priority     = "${var.priority+var.listener_arns[count.index]}"
 

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,52 @@
+locals {
+  generate_target_group_arn = "${var.target_group_arn == "" ? 1 : 0}"
+}
+
+module "default_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.3.5"
+  enabled    = "${local.generate_target_group_arn}"
+  attributes = "${var.attributes}"
+  delimiter  = "${var.delimiter}"
+  name       = "${var.name}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  tags       = "${var.tags}"
+}
+
+locals {
+  target_group_arn = "${local.generate_target_group_arn ? aws_lb_target_group.default.arn : var.target_group_arn}"
+}
+
+resource "aws_lb_target_group" "default" {
+  count       = "${local.generate_target_group_arn}"
+  name        = "${module.default_label.id}"
+  port        = "${var.port}"
+  protocol    = "${var.protocol}"
+  vpc_id      = "${var.vpc_id}"
+  target_type = "${var.target_type}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_listener_rule" "default" {
+  count        = "${count(var.listener_arns)}"
+  listener_arn = "${var.listener_arns[count.index]}"
+  priority     = "${var.priority+var.listener_arns[count.index]}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${local.target_group_arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${var.hosts}"]
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["${var.paths}"]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "aws_lb_target_group" "default" {
 }
 
 resource "aws_lb_listener_rule" "default" {
-  count        = "1"
+  count        = "${length(var.listener_arns)}"
   listener_arn = "${var.listener_arns[count.index]}"
   priority     = "${var.priority + count.index}"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "target_group_arn" {
+  value = "${local.target_group_arn}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -30,54 +30,66 @@ variable "tags" {
 
 variable "target_group_arn" {
   default = ""
+  description = "ALB target group ARN, if this is an empty string a new one will be generated"
 }
 
 variable "listener_arns" {
   type    = "list"
   default = []
+  description = "A list of ALB listener ARNs to attach ALB listener rule to"
 }
 
 variable "deregistration_delay" {
   default = "15"
+  description = "The amount of time to wait in seconds while deregistering target"
 }
 
 variable "health_check_path" {
   default = "/"
+  description = "The destination for the health check request"
 }
 
 variable "health_check_timeout" {
   default = "10"
+  description = "The amount of time to wait in seconds before failing a health check request"
 }
 
 variable "health_check_healthy_threshold" {
   default = "2"
+  description = "The number of consecutive health checks successes required before healthy"
 }
 
 variable "health_check_unhealthy_threshold" {
   default = "2"
+  description = "The number of consecutive health check failures required before unhealthy"
 }
 
 variable "health_check_interval" {
   default = "15"
+  description = "The duration in seconds in between health checks"
 }
 
 variable "health_check_matcher" {
   default = "200-399"
+  description = "The HTTP response codes to indicate a healthy check"
 }
 
 variable "priority" {
   type    = "string"
   default = "100"
+  description = "The priority for the rule between 1 and 50000 (1 being highest priority)"
 }
 
 variable "port" {
   type    = "string"
   default = "80"
+  description = "The port for generated ALB target group (if target_group_arn not set)"
 }
 
 variable "protocol" {
   type    = "string"
   default = "HTTP"
+  description = "The protocol for generated ALB target group (if target_group_arn not set)"
 }
 
 variable "target_type" {
@@ -87,14 +99,12 @@ variable "target_type" {
 
 variable "vpc_id" {
   type = "string"
-}
-
-variable "hosts" {
-  type    = "list"
-  default = ["*"]
+  default = ""
+  description = "The VPC ID where generated ALB target group will be provisioned (if target_group_arn not set)"
 }
 
 variable "paths" {
   type    = "list"
   default = ["/*"]
+  description = "Path pattern to match (a maximum of 1 can be defined)"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,34 @@ variable "tags" {
   description = "Additional tags (e.g. `map(`BusinessUnit`,`XYZ`)"
 }
 
+variable "deregistration_delay" {
+  default = "15"
+}
+
+variable "health_check_path" {
+  default = "/"
+}
+
+variable "health_check_timeout" {
+  default = "10"
+}
+
+variable "health_check_healthy_threshold" {
+  default = "2"
+}
+
+variable "health_check_unhealthy_threshold" {
+  default = "2"
+}
+
+variable "health_check_interval" {
+  default = "15"
+}
+
+variable "health_check_matcher" {
+  default = "200-399"
+}
+
 variable "priority" {
   type    = "string"
   default = "100"

--- a/variables.tf
+++ b/variables.tf
@@ -71,13 +71,13 @@ variable "priority" {
 }
 
 variable "port" {
-  type  = "string"
-  value = "80"
+  type    = "string"
+  default = "80"
 }
 
 variable "protocol" {
-  type  = "string"
-  value = "HTTP"
+  type    = "string"
+  default = "HTTP"
 }
 
 variable "target_type" {
@@ -90,11 +90,11 @@ variable "vpc_id" {
 }
 
 variable "hosts" {
-  type  = "list"
-  value = ["*"]
+  type    = "list"
+  default = ["*"]
 }
 
 variable "paths" {
-  type  = "list"
-  value = ["/*"]
+  type    = "list"
+  default = ["/*"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,63 @@
+variable "namespace" {
+  description = "Namespace, which could be your organization name, e.g. `cp` or `cloudposse`"
+}
+
+variable "stage" {
+  description = "Stage, e.g. `prod`, `staging`, `dev`, or `test`"
+}
+
+variable "name" {
+  description = "Solution name, e.g. `app`"
+}
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `name`, `stage` and `attributes`"
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes, e.g. `1`"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. `map(`BusinessUnit`,`XYZ`)"
+}
+
+variable "priority" {
+  type    = "string"
+  default = "100"
+}
+
+variable "port" {
+  type  = "string"
+  value = "80"
+}
+
+variable "protocol" {
+  type  = "string"
+  value = "HTTP"
+}
+
+variable "target_type" {
+  type    = "string"
+  default = "ip"
+}
+
+variable "vpc_id" {
+  type = "string"
+}
+
+variable "hosts" {
+  type  = "list"
+  value = ["*"]
+}
+
+variable "paths" {
+  type  = "list"
+  value = ["/*"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -29,66 +29,66 @@ variable "tags" {
 }
 
 variable "target_group_arn" {
-  default = ""
+  default     = ""
   description = "ALB target group ARN, if this is an empty string a new one will be generated"
 }
 
 variable "listener_arns" {
-  type    = "list"
-  default = []
+  type        = "list"
+  default     = []
   description = "A list of ALB listener ARNs to attach ALB listener rule to"
 }
 
 variable "deregistration_delay" {
-  default = "15"
+  default     = "15"
   description = "The amount of time to wait in seconds while deregistering target"
 }
 
 variable "health_check_path" {
-  default = "/"
+  default     = "/"
   description = "The destination for the health check request"
 }
 
 variable "health_check_timeout" {
-  default = "10"
+  default     = "10"
   description = "The amount of time to wait in seconds before failing a health check request"
 }
 
 variable "health_check_healthy_threshold" {
-  default = "2"
+  default     = "2"
   description = "The number of consecutive health checks successes required before healthy"
 }
 
 variable "health_check_unhealthy_threshold" {
-  default = "2"
+  default     = "2"
   description = "The number of consecutive health check failures required before unhealthy"
 }
 
 variable "health_check_interval" {
-  default = "15"
+  default     = "15"
   description = "The duration in seconds in between health checks"
 }
 
 variable "health_check_matcher" {
-  default = "200-399"
+  default     = "200-399"
   description = "The HTTP response codes to indicate a healthy check"
 }
 
 variable "priority" {
-  type    = "string"
-  default = "100"
+  type        = "string"
+  default     = "100"
   description = "The priority for the rule between 1 and 50000 (1 being highest priority)"
 }
 
 variable "port" {
-  type    = "string"
-  default = "80"
+  type        = "string"
+  default     = "80"
   description = "The port for generated ALB target group (if target_group_arn not set)"
 }
 
 variable "protocol" {
-  type    = "string"
-  default = "HTTP"
+  type        = "string"
+  default     = "HTTP"
   description = "The protocol for generated ALB target group (if target_group_arn not set)"
 }
 
@@ -98,13 +98,19 @@ variable "target_type" {
 }
 
 variable "vpc_id" {
-  type = "string"
-  default = ""
+  type        = "string"
+  default     = ""
   description = "The VPC ID where generated ALB target group will be provisioned (if target_group_arn not set)"
 }
 
+variable "hosts" {
+  type        = "list"
+  default     = []
+  description = "Hosts to match in Hosts header"
+}
+
 variable "paths" {
-  type    = "list"
-  default = ["/*"]
+  type        = "list"
+  default     = []
   description = "Path pattern to match (a maximum of 1 can be defined)"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "target_group_arn" {
 }
 
 variable "listener_arns" {
-  type = "list"
+  type    = "list"
   default = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,15 @@ variable "tags" {
   description = "Additional tags (e.g. `map(`BusinessUnit`,`XYZ`)"
 }
 
+variable "target_group_arn" {
+  default = ""
+}
+
+variable "listener_arns" {
+  type = "list"
+  default = []
+}
+
 variable "deregistration_delay" {
   default = "15"
 }


### PR DESCRIPTION
## what
* Create ALB listener rules that behave like a "normal" HTTP ingress
* Generate target group if necessary

## why
* Make it easy to send requests from multiple listeners (E.g. HTTP/HTTPS) to a single target group