### PR TITLE
Expose additional ALB Target ouputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | target_group_arn | ALB Target group ARN |
+| target_group_arn_suffix | ALB Target group ARN suffix |
+| target_group_name | ALB Target group name |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -32,4 +32,6 @@
 | Name | Description |
 |------|-------------|
 | target_group_arn | ALB Target group ARN |
+| target_group_arn_suffix | ALB Target group ARN suffix |
+| target_group_name | ALB Target group name |
 

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,10 @@ locals {
   target_group_arn = "${local.generate_target_group_arn ? aws_lb_target_group.default.arn : var.target_group_arn}"
 }
 
+data "aws_lb_target_group" "default" {
+  arn = "${local.target_group_arn}"
+}
+
 module "default_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.3"
   enabled    = "${local.generate_target_group_arn}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,14 @@
+output "target_group_name" {
+  description = "ALB Target group name"
+  value       = "${data.aws_lb_target_group.default.name}"
+}
+
 output "target_group_arn" {
   description = "ALB Target group ARN"
-  value       = "${local.target_group_arn}"
+  value       = "${data.aws_lb_target_group.default.arn}"
+}
+
+output "target_group_arn_suffix" {
+  description = "ALB Target group ARN suffix"
+  value       = "${data.aws_lb_target_group.default.arn_suffix}"
 }


### PR DESCRIPTION
## what
Expose additional ALB Target outputs.

## why
Pass in outputs as parameters to CloudWatch Alarm modules (and others).