### PR TITLE
Fix authentication action. Don't use `map` variable for authentication action

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,25 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ## Usage
 
+
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-alb-ingress/releases).
+
+
 Include this module in your existing terraform code:
 
 ```hcl
 module "alb_ingress" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=tags/0.2.0"
+  source             = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=master"
   namespace          = "eg"
   name               = "app"
   stage              = "dev"
 
-  vpc_id              = "xxxxxxxx"
-  listener_arns       = ["xxxxxx", "yyyyyyy"]
-  listener_arns_count = "2"
-  health_check_path   = "/healthz"
-  paths               = ["/*"]
+  vpc_id                              = "xxxxxxxx"
+  unauthenticated_listener_arns       = ["xxxxxx", "yyyyyyy"]
+  unauthenticated_listener_arns_count = "2"
+  health_check_path                   = "/healthz"
+  unauthenticated_paths               = ["/*"]
 }
 ```
 
@@ -80,9 +85,20 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes, e.g. `1` | list | `<list>` | no |
 | authenticated_hosts | Authenticated hosts to match in Hosts header | list | `<list>` | no |
+| authenticated_listener_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
+| authenticated_listener_arns_count | The number of authenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | authenticated_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | authenticated_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `unauthenticated_priority` since a listener can't have multiple rules with the same priority | string | `300` | no |
-| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authenticated_hosts` or `authenticated_paths` are provided | map | `<map>` | no |
+| authentication_cognito_user_pool_arn | Cognito User Pool ARN | string | `` | no |
+| authentication_cognito_user_pool_client_id | Cognito User Pool Client ID | string | `` | no |
+| authentication_cognito_user_pool_domain | Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com) | string | `` | no |
+| authentication_oidc_authorization_endpoint | OIDC Authorization Endpoint | string | `` | no |
+| authentication_oidc_client_id | OIDC Client ID | string | `` | no |
+| authentication_oidc_client_secret | OIDC Client Secret | string | `` | no |
+| authentication_oidc_issuer | OIDC Issuer | string | `` | no |
+| authentication_oidc_token_endpoint | OIDC Token Endpoint | string | `` | no |
+| authentication_oidc_user_info_endpoint | OIDC User Info Endpoint | string | `` | no |
+| authentication_type | Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE` | string | `NONE` | no |
 | delimiter | Delimiter to be used between `namespace`, `name`, `stage` and `attributes` | string | `-` | no |
 | deregistration_delay | The amount of time to wait in seconds while deregistering target | string | `15` | no |
 | health_check_healthy_threshold | The number of consecutive health checks successes required before healthy | string | `2` | no |
@@ -91,8 +107,6 @@ Available targets:
 | health_check_path | The destination for the health check request | string | `/` | no |
 | health_check_timeout | The amount of time to wait in seconds before failing a health check request | string | `10` | no |
 | health_check_unhealthy_threshold | The number of consecutive health check failures required before unhealthy | string | `2` | no |
-| listener_arns | A list of ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
-| listener_arns_count | The number of ARNs in `listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | name | Solution name, e.g. `app` | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. `cp` or `cloudposse` | string | - | yes |
 | port | The port for generated ALB target group (if `target_group_arn` not set) | string | `80` | no |
@@ -102,6 +116,8 @@ Available targets:
 | target_group_arn | ALB target group ARN. If this is an empty string, a new one will be generated | string | `` | no |
 | target_type | - | string | `ip` | no |
 | unauthenticated_hosts | Unauthenticated hosts to match in Hosts header | list | `<list>` | no |
+| unauthenticated_listener_arns | A list of unauthenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
+| unauthenticated_listener_arns_count | The number of unauthenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | unauthenticated_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | unauthenticated_priority | The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `authenticated_priority` since a listener can't have multiple rules with the same priority | string | `100` | no |
 | vpc_id | The VPC ID where generated ALB target group will be provisioned (if `target_group_arn` is not set) | string | - | yes |

--- a/README.yaml
+++ b/README.yaml
@@ -43,16 +43,16 @@ usage: |-
 
   ```hcl
   module "alb_ingress" {
-    source              = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=tags/0.2.0"
+    source             = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=master"
     namespace          = "eg"
     name               = "app"
     stage              = "dev"
 
-    vpc_id              = "xxxxxxxx"
-    listener_arns       = ["xxxxxx", "yyyyyyy"]
-    listener_arns_count = "2"
-    health_check_path   = "/healthz"
-    paths               = ["/*"]
+    vpc_id                              = "xxxxxxxx"
+    unauthenticated_listener_arns       = ["xxxxxx", "yyyyyyy"]
+    unauthenticated_listener_arns_count = "2"
+    health_check_path                   = "/healthz"
+    unauthenticated_paths               = ["/*"]
   }
   ```
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,9 +4,20 @@
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes, e.g. `1` | list | `<list>` | no |
 | authenticated_hosts | Authenticated hosts to match in Hosts header | list | `<list>` | no |
+| authenticated_listener_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
+| authenticated_listener_arns_count | The number of authenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | authenticated_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | authenticated_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `unauthenticated_priority` since a listener can't have multiple rules with the same priority | string | `300` | no |
-| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authenticated_hosts` or `authenticated_paths` are provided | map | `<map>` | no |
+| authentication_cognito_user_pool_arn | Cognito User Pool ARN | string | `` | no |
+| authentication_cognito_user_pool_client_id | Cognito User Pool Client ID | string | `` | no |
+| authentication_cognito_user_pool_domain | Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com) | string | `` | no |
+| authentication_oidc_authorization_endpoint | OIDC Authorization Endpoint | string | `` | no |
+| authentication_oidc_client_id | OIDC Client ID | string | `` | no |
+| authentication_oidc_client_secret | OIDC Client Secret | string | `` | no |
+| authentication_oidc_issuer | OIDC Issuer | string | `` | no |
+| authentication_oidc_token_endpoint | OIDC Token Endpoint | string | `` | no |
+| authentication_oidc_user_info_endpoint | OIDC User Info Endpoint | string | `` | no |
+| authentication_type | Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE` | string | `NONE` | no |
 | delimiter | Delimiter to be used between `namespace`, `name`, `stage` and `attributes` | string | `-` | no |
 | deregistration_delay | The amount of time to wait in seconds while deregistering target | string | `15` | no |
 | health_check_healthy_threshold | The number of consecutive health checks successes required before healthy | string | `2` | no |
@@ -15,8 +26,6 @@
 | health_check_path | The destination for the health check request | string | `/` | no |
 | health_check_timeout | The amount of time to wait in seconds before failing a health check request | string | `10` | no |
 | health_check_unhealthy_threshold | The number of consecutive health check failures required before unhealthy | string | `2` | no |
-| listener_arns | A list of ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
-| listener_arns_count | The number of ARNs in `listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | name | Solution name, e.g. `app` | string | - | yes |
 | namespace | Namespace, which could be your organization name, e.g. `cp` or `cloudposse` | string | - | yes |
 | port | The port for generated ALB target group (if `target_group_arn` not set) | string | `80` | no |
@@ -26,6 +35,8 @@
 | target_group_arn | ALB target group ARN. If this is an empty string, a new one will be generated | string | `` | no |
 | target_type | - | string | `ip` | no |
 | unauthenticated_hosts | Unauthenticated hosts to match in Hosts header | list | `<list>` | no |
+| unauthenticated_listener_arns | A list of unauthenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
+| unauthenticated_listener_arns_count | The number of unauthenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | unauthenticated_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | unauthenticated_priority | The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `authenticated_priority` since a listener can't have multiple rules with the same priority | string | `100` | no |
 | vpc_id | The VPC ID where generated ALB target group will be provisioned (if `target_group_arn` is not set) | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ locals {
       }]
     }
 
-    "GOOGLE_OIDC" = {
+    "OIDC" = {
       type = "authenticate-oidc"
 
       authenticate_oidc = [{

--- a/variables.tf
+++ b/variables.tf
@@ -37,16 +37,28 @@ variable "target_group_arn" {
   description = "ALB target group ARN. If this is an empty string, a new one will be generated"
 }
 
-variable "listener_arns" {
+variable "unauthenticated_listener_arns" {
   type        = "list"
   default     = []
-  description = "A list of ALB listener ARNs to attach ALB listener rules to"
+  description = "A list of unauthenticated ALB listener ARNs to attach ALB listener rules to"
 }
 
-variable "listener_arns_count" {
+variable "unauthenticated_listener_arns_count" {
   type        = "string"
   default     = "0"
-  description = "The number of ARNs in `listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
+  description = "The number of unauthenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
+}
+
+variable "authenticated_listener_arns" {
+  type        = "list"
+  default     = []
+  description = "A list of authenticated ALB listener ARNs to attach ALB listener rules to"
+}
+
+variable "authenticated_listener_arns_count" {
+  type        = "string"
+  default     = "0"
+  description = "The number of authenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
 }
 
 variable "deregistration_delay" {
@@ -149,8 +161,62 @@ variable "authenticated_paths" {
   description = "Authenticated path pattern to match (a maximum of 1 can be defined)"
 }
 
-variable "authentication_action" {
-  type        = "map"
-  default     = {}
-  description = "Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authenticated_hosts` or `authenticated_paths` are provided"
+variable "authentication_type" {
+  type        = "string"
+  default     = "NONE"
+  description = "Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE`"
+}
+
+variable "authentication_cognito_user_pool_arn" {
+  type        = "string"
+  description = "Cognito User Pool ARN"
+  default     = ""
+}
+
+variable "authentication_cognito_user_pool_client_id" {
+  type        = "string"
+  description = "Cognito User Pool Client ID"
+  default     = ""
+}
+
+variable "authentication_cognito_user_pool_domain" {
+  type        = "string"
+  description = "Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com)"
+  default     = ""
+}
+
+variable "authentication_oidc_client_id" {
+  type        = "string"
+  description = "OIDC Client ID"
+  default     = ""
+}
+
+variable "authentication_oidc_client_secret" {
+  type        = "string"
+  description = "OIDC Client Secret"
+  default     = ""
+}
+
+variable "authentication_oidc_issuer" {
+  type        = "string"
+  description = "OIDC Issuer"
+  default     = ""
+}
+
+variable "authentication_oidc_authorization_endpoint" {
+  type        = "string"
+  description = "OIDC Authorization Endpoint"
+  default     = ""
+}
+
+variable "authentication_oidc_token_endpoint" {
+  type        = "string"
+  description = "OIDC Token Endpoint"
+  default     = ""
+}
+
+variable "authentication_oidc_user_info_endpoint" {
+  type        = "string"
+  description = "OIDC User Info Endpoint"
+  default     = ""
 }


### PR DESCRIPTION
## what
* Fix authentication action
* Don't use `map` variable for authentication action

## why
* Using `authentication_action` variable as `map` breaks when this module is used in a chain of calls from other modules
For example:
   * Providing `authentication_action` map from Module B to `alb-ingress` - works
   * Providing `authentication_action` map from Module C to Module B to `alb-ingress` - works
   * Providing `authentication_action` map from Module D to Module C to Module B to `alb-ingress` - breaks (in a way that is very difficult to understand and debug; the end result is that `alb-ingress` receives an empty or incomplete map)

