### PR TITLE
Add separate listener rules for authentication type `OIDC` and `COGNITO`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Available targets:
 | attributes | Additional attributes, e.g. `1` | list | `<list>` | no |
 | authenticated_hosts | Authenticated hosts to match in Hosts header | list | `<list>` | no |
 | authenticated_listener_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
-| authenticated_listener_arns_count | The number of authenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
+| authenticated_listener_arns_count | The number of authenticated ARNs in `authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | authenticated_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | authenticated_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `unauthenticated_priority` since a listener can't have multiple rules with the same priority | string | `300` | no |
 | authentication_cognito_user_pool_arn | Cognito User Pool ARN | string | `` | no |
@@ -98,7 +98,7 @@ Available targets:
 | authentication_oidc_issuer | OIDC Issuer | string | `` | no |
 | authentication_oidc_token_endpoint | OIDC Token Endpoint | string | `` | no |
 | authentication_oidc_user_info_endpoint | OIDC User Info Endpoint | string | `` | no |
-| authentication_type | Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE` | string | `NONE` | no |
+| authentication_type | Authentication type. Supported values are `COGNITO` and `OIDC` | string | `` | no |
 | delimiter | Delimiter to be used between `namespace`, `name`, `stage` and `attributes` | string | `-` | no |
 | deregistration_delay | The amount of time to wait in seconds while deregistering target | string | `15` | no |
 | health_check_healthy_threshold | The number of consecutive health checks successes required before healthy | string | `2` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,7 +5,7 @@
 | attributes | Additional attributes, e.g. `1` | list | `<list>` | no |
 | authenticated_hosts | Authenticated hosts to match in Hosts header | list | `<list>` | no |
 | authenticated_listener_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
-| authenticated_listener_arns_count | The number of authenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
+| authenticated_listener_arns_count | The number of authenticated ARNs in `authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | authenticated_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | authenticated_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `unauthenticated_priority` since a listener can't have multiple rules with the same priority | string | `300` | no |
 | authentication_cognito_user_pool_arn | Cognito User Pool ARN | string | `` | no |
@@ -17,7 +17,7 @@
 | authentication_oidc_issuer | OIDC Issuer | string | `` | no |
 | authentication_oidc_token_endpoint | OIDC Token Endpoint | string | `` | no |
 | authentication_oidc_user_info_endpoint | OIDC User Info Endpoint | string | `` | no |
-| authentication_type | Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE` | string | `NONE` | no |
+| authentication_type | Authentication type. Supported values are `COGNITO` and `OIDC` | string | `` | no |
 | delimiter | Delimiter to be used between `namespace`, `name`, `stage` and `attributes` | string | `-` | no |
 | deregistration_delay | The amount of time to wait in seconds while deregistering target | string | `15` | no |
 | health_check_healthy_threshold | The number of consecutive health checks successes required before healthy | string | `2` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "authenticated_listener_arns" {
 variable "authenticated_listener_arns_count" {
   type        = "string"
   default     = "0"
-  description = "The number of authenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
+  description = "The number of authenticated ARNs in `authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
 }
 
 variable "deregistration_delay" {
@@ -163,8 +163,8 @@ variable "authenticated_paths" {
 
 variable "authentication_type" {
   type        = "string"
-  default     = "NONE"
-  description = "Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE`"
+  default     = ""
+  description = "Authentication type. Supported values are `COGNITO` and `OIDC`"
 }
 
 variable "authentication_cognito_user_pool_arn" {


### PR DESCRIPTION
## what
* Add separate listener rules for authentication type `OIDC` and `COGNITO` (with the authentication action embedded in the rules)

## why
* Having the authentication action map in locals did not work when the map's values were read from SSM parameter store in top-level modules
