### PR TITLE
Migrate away from deprecated listener condition format

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 2.42 |
 | local | ~> 1.3 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
@@ -206,7 +206,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 2.42 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
+| aws | ~> 2.42 |
 | local | ~> 1.3 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | ~> 2.42 |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -64,8 +64,9 @@ resource "aws_lb_listener_rule" "unauthenticated_paths" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = var.unauthenticated_paths
+    path_pattern {
+      values = var.unauthenticated_paths
+    }
   }
 }
 
@@ -94,8 +95,9 @@ resource "aws_lb_listener_rule" "authenticated_paths_oidc" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = var.authenticated_paths
+    path_pattern {
+      values = var.authenticated_paths
+    }
   }
 }
 
@@ -121,8 +123,9 @@ resource "aws_lb_listener_rule" "authenticated_paths_cognito" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = var.authenticated_paths
+    path_pattern {
+      values = var.authenticated_paths
+    }
   }
 }
 
@@ -138,8 +141,9 @@ resource "aws_lb_listener_rule" "unauthenticated_hosts" {
   }
 
   condition {
-    field  = "host-header"
-    values = var.unauthenticated_hosts
+    host_header {
+      values = var.unauthenticated_hosts
+    }
   }
 }
 
@@ -168,8 +172,9 @@ resource "aws_lb_listener_rule" "authenticated_hosts_oidc" {
   }
 
   condition {
-    field  = "host-header"
-    values = var.authenticated_hosts
+    host_header {
+      values = var.authenticated_hosts
+    }
   }
 }
 
@@ -195,8 +200,9 @@ resource "aws_lb_listener_rule" "authenticated_hosts_cognito" {
   }
 
   condition {
-    field  = "host-header"
-    values = var.authenticated_hosts
+    host_header {
+      values = var.authenticated_hosts
+    }
   }
 }
 
@@ -212,13 +218,15 @@ resource "aws_lb_listener_rule" "unauthenticated_hosts_paths" {
   }
 
   condition {
-    field  = "host-header"
-    values = var.unauthenticated_hosts
+    host_header {
+      values = var.unauthenticated_hosts
+    }
   }
 
   condition {
-    field  = "path-pattern"
-    values = var.unauthenticated_paths
+    path_pattern {
+      values = var.unauthenticated_paths
+    }
   }
 }
 
@@ -247,13 +255,15 @@ resource "aws_lb_listener_rule" "authenticated_hosts_paths_oidc" {
   }
 
   condition {
-    field  = "host-header"
-    values = var.authenticated_hosts
+    host_header {
+      values = var.authenticated_hosts
+    }
   }
 
   condition {
-    field  = "path-pattern"
-    values = var.authenticated_paths
+    path_pattern {
+      values = var.authenticated_paths
+    }
   }
 }
 
@@ -279,12 +289,14 @@ resource "aws_lb_listener_rule" "authenticated_hosts_paths_cognito" {
   }
 
   condition {
-    field  = "host-header"
-    values = var.authenticated_hosts
+    host_header {
+      values = var.authenticated_hosts
+    }
   }
 
   condition {
-    field  = "path-pattern"
-    values = var.authenticated_paths
+    path_pattern {
+      values = var.authenticated_paths
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 0.12.0"
 
   required_providers {
-    aws      = "~> 2.0"
+    aws      = "~> 2.42"
     template = "~> 2.0"
     null     = "~> 2.0"
     local    = "~> 1.3"


### PR DESCRIPTION
This deprecation was introduced in v2.42 of the aws provider, so
bumping requirement `versions.tf`, too.

## what
* Migrates the `condition` blocks away from the deprecated  `field`/`values` variant in favor of the current block-syntax.

## why
* Recent versions of the aws provider do no longer work with lists for hosts/paths.

## references
* https://github.com/terraform-providers/terraform-provider-aws/pull/8268
* https://github.com/terraform-providers/terraform-provider-aws/issues/10586
