### PR TITLE
feat: add scope to oidc listener rule configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Available targets:
 | authenticated\_listener\_arns\_count | The number of authenticated ARNs in `authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
 | authenticated\_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | `list(string)` | `[]` | no |
 | authenticated\_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `unauthenticated_priority` since a listener can't have multiple rules with the same priority | `number` | `0` | no |
+| authentication\_cognito\_scope | Cognito scope | `list(string)` | `[]` | no |
 | authentication\_cognito\_user\_pool\_arn | Cognito User Pool ARN | `string` | `""` | no |
 | authentication\_cognito\_user\_pool\_client\_id | Cognito User Pool Client ID | `string` | `""` | no |
 | authentication\_cognito\_user\_pool\_domain | Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com) | `string` | `""` | no |
@@ -207,6 +208,7 @@ Available targets:
 | authentication\_oidc\_client\_id | OIDC Client ID | `string` | `""` | no |
 | authentication\_oidc\_client\_secret | OIDC Client Secret | `string` | `""` | no |
 | authentication\_oidc\_issuer | OIDC Issuer | `string` | `""` | no |
+| authentication\_oidc\_scope | OIDC scope | `list(string)` | `[]` | no |
 | authentication\_oidc\_token\_endpoint | OIDC Token Endpoint | `string` | `""` | no |
 | authentication\_oidc\_user\_info\_endpoint | OIDC User Info Endpoint | `string` | `""` | no |
 | authentication\_type | Authentication type. Supported values are `COGNITO` and `OIDC` | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -252,6 +253,7 @@ Available targets:
 | target\_group\_arn\_suffix | ALB Target Group ARN suffix |
 | target\_group\_name | ALB Target Group name |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -76,3 +77,4 @@
 | target\_group\_arn\_suffix | ALB Target Group ARN suffix |
 | target\_group\_name | ALB Target Group name |
 
+<!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,6 +24,7 @@
 | authenticated\_listener\_arns\_count | The number of authenticated ARNs in `authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
 | authenticated\_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | `list(string)` | `[]` | no |
 | authenticated\_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `unauthenticated_priority` since a listener can't have multiple rules with the same priority | `number` | `0` | no |
+| authentication\_cognito\_scope | Cognito scope | `list(string)` | `[]` | no |
 | authentication\_cognito\_user\_pool\_arn | Cognito User Pool ARN | `string` | `""` | no |
 | authentication\_cognito\_user\_pool\_client\_id | Cognito User Pool Client ID | `string` | `""` | no |
 | authentication\_cognito\_user\_pool\_domain | Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com) | `string` | `""` | no |
@@ -31,6 +32,7 @@
 | authentication\_oidc\_client\_id | OIDC Client ID | `string` | `""` | no |
 | authentication\_oidc\_client\_secret | OIDC Client Secret | `string` | `""` | no |
 | authentication\_oidc\_issuer | OIDC Issuer | `string` | `""` | no |
+| authentication\_oidc\_scope | OIDC scope | `list(string)` | `[]` | no |
 | authentication\_oidc\_token\_endpoint | OIDC Token Endpoint | `string` | `""` | no |
 | authentication\_oidc\_user\_info\_endpoint | OIDC User Info Endpoint | `string` | `""` | no |
 | authentication\_type | Authentication type. Supported values are `COGNITO` and `OIDC` | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,7 @@
 locals {
-  target_group_arn = var.default_target_group_enabled ? join("", aws_lb_target_group.default.*.arn) : var.target_group_arn
+  target_group_arn             = var.default_target_group_enabled ? join("", aws_lb_target_group.default.*.arn) : var.target_group_arn
+  authentication_oidc_scope    = length(var.authentication_oidc_scope) > 0 ? join("%20", [for scope in var.authentication_oidc_scope: urlencode(scope)]) : null
+  authentication_cognito_scope = length(var.authentication_cognito_scope) > 0 ? join("%20", [for scope in var.authentication_cognito_scope: urlencode(scope)]) : null
 }
 
 data "aws_lb_target_group" "default" {
@@ -86,6 +88,7 @@ resource "aws_lb_listener_rule" "authenticated_paths_oidc" {
       authorization_endpoint = var.authentication_oidc_authorization_endpoint
       token_endpoint         = var.authentication_oidc_token_endpoint
       user_info_endpoint     = var.authentication_oidc_user_info_endpoint
+      scope                  = local.authentication_oidc_scope
     }
   }
 
@@ -114,6 +117,7 @@ resource "aws_lb_listener_rule" "authenticated_paths_cognito" {
       user_pool_arn       = var.authentication_cognito_user_pool_arn
       user_pool_client_id = var.authentication_cognito_user_pool_client_id
       user_pool_domain    = var.authentication_cognito_user_pool_domain
+      scope               = local.authentication_cognito_scope
     }
   }
 
@@ -163,6 +167,7 @@ resource "aws_lb_listener_rule" "authenticated_hosts_oidc" {
       authorization_endpoint = var.authentication_oidc_authorization_endpoint
       token_endpoint         = var.authentication_oidc_token_endpoint
       user_info_endpoint     = var.authentication_oidc_user_info_endpoint
+      scope                  = local.authentication_oidc_scope
     }
   }
 
@@ -191,6 +196,7 @@ resource "aws_lb_listener_rule" "authenticated_hosts_cognito" {
       user_pool_arn       = var.authentication_cognito_user_pool_arn
       user_pool_client_id = var.authentication_cognito_user_pool_client_id
       user_pool_domain    = var.authentication_cognito_user_pool_domain
+      scope               = local.authentication_cognito_scope
     }
   }
 
@@ -246,6 +252,7 @@ resource "aws_lb_listener_rule" "authenticated_hosts_paths_oidc" {
       authorization_endpoint = var.authentication_oidc_authorization_endpoint
       token_endpoint         = var.authentication_oidc_token_endpoint
       user_info_endpoint     = var.authentication_oidc_user_info_endpoint
+      scope                  = local.authentication_oidc_scope
     }
   }
 
@@ -280,6 +287,7 @@ resource "aws_lb_listener_rule" "authenticated_hosts_paths_cognito" {
       user_pool_arn       = var.authentication_cognito_user_pool_arn
       user_pool_client_id = var.authentication_cognito_user_pool_client_id
       user_pool_domain    = var.authentication_cognito_user_pool_domain
+      scope               = local.authentication_cognito_scope
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   target_group_arn             = var.default_target_group_enabled ? join("", aws_lb_target_group.default.*.arn) : var.target_group_arn
-  authentication_oidc_scope    = length(var.authentication_oidc_scope) > 0 ? join("%20", [for scope in var.authentication_oidc_scope: urlencode(scope)]) : null
-  authentication_cognito_scope = length(var.authentication_cognito_scope) > 0 ? join("%20", [for scope in var.authentication_cognito_scope: urlencode(scope)]) : null
+  authentication_oidc_scope    = length(var.authentication_oidc_scope) > 0 ? join("%20", [for scope in var.authentication_oidc_scope : urlencode(scope)]) : null
+  authentication_cognito_scope = length(var.authentication_cognito_scope) > 0 ? join("%20", [for scope in var.authentication_cognito_scope : urlencode(scope)]) : null
 }
 
 data "aws_lb_target_group" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -218,6 +218,12 @@ variable "authentication_cognito_user_pool_domain" {
   default     = ""
 }
 
+variable "authentication_cognito_scope" {
+  type        = list(string)
+  description = "Cognito scope"
+  default     = []
+}
+
 variable "authentication_oidc_client_id" {
   type        = string
   description = "OIDC Client ID"
@@ -252,6 +258,12 @@ variable "authentication_oidc_user_info_endpoint" {
   type        = string
   description = "OIDC User Info Endpoint"
   default     = ""
+}
+
+variable "authentication_oidc_scope" {
+  type        = list(string)
+  description = "OIDC scope"
+  default     = []
 }
 
 variable "slow_start" {


### PR DESCRIPTION
## what
* expose scopes for OIDC / cognito

## why
* allow the default provider scopes to be expanded upon
