### PR TITLE
Adding optional http_headers condition to listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+<!-- markdownlint-disable -->
 # terraform-aws-alb-ingress [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-alb-ingress.svg)](https://github.com/cloudposse/terraform-aws-alb-ingress/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+<!-- markdownlint-restore -->
 
 [![README Header][readme_header_img]][readme_header_link]
 
@@ -64,8 +66,15 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Usage
 
 
-**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
-Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-alb-ingress/releases).
+**IMPORTANT:** We do not pin modules to versions in our examples because of the
+difficulty of keeping the versions in the documentation in sync with the latest released versions.
+We highly recommend that in your code you pin the version to the exact version you are
+using so that your infrastructure remains stable, and update versions in a
+systematic way so that they do not catch you by surprise.
+
+Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
+the registry shows many of our inputs as required when in fact they are optional.
+The table below correctly indicates which inputs are required.
 
 
 For a complete example, see [examples/complete](examples/complete).
@@ -230,6 +239,7 @@ Available targets:
 | health\_check\_unhealthy\_threshold | The number of consecutive health check failures required before unhealthy | `number` | `2` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| listener\_http\_header\_conditions | A list of http header conditions to apply to the listener. | <pre>list(object({<br>    name  = string<br>    value = list(string)<br>  }))</pre> | `[]` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | port | The port for the created ALB target group (if `target_group_arn` is not set) | `number` | `80` | no |
@@ -348,7 +358,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 
@@ -405,8 +415,10 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
+<!-- markdownlint-disable -->
 |  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sarkis Varozian][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis Varozian][sarkis_homepage] |
 |---|---|---|---|
+<!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -55,6 +55,7 @@
 | health\_check\_unhealthy\_threshold | The number of consecutive health check failures required before unhealthy | `number` | `2` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| listener\_http\_header\_conditions | A list of http header conditions to apply to the listener. | <pre>list(object({<br>    name  = string<br>    value = list(string)<br>  }))</pre> | `[]` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | port | The port for the created ALB target group (if `target_group_arn` is not set) | `number` | `80` | no |

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,17 @@ resource "aws_lb_listener_rule" "unauthenticated_paths" {
       values = var.unauthenticated_paths
     }
   }
+
+  condition {
+    dynamic "http_header" {
+      for_each = var.listener_http_header_conditions
+
+      content {
+        http_header_name = http_header.value["name"]
+        values           = http_header.value["value"]
+      }
+    }
+  }
 }
 
 resource "aws_lb_listener_rule" "authenticated_paths_oidc" {
@@ -90,6 +101,17 @@ resource "aws_lb_listener_rule" "authenticated_paths_oidc" {
       values = var.authenticated_paths
     }
   }
+
+  condition {
+    dynamic "http_header" {
+      for_each = var.listener_http_header_conditions
+
+      content {
+        http_header_name = http_header.value["name"]
+        values           = http_header.value["value"]
+      }
+    }
+  }
 }
 
 resource "aws_lb_listener_rule" "authenticated_paths_cognito" {
@@ -117,6 +139,17 @@ resource "aws_lb_listener_rule" "authenticated_paths_cognito" {
   condition {
     path_pattern {
       values = var.authenticated_paths
+    }
+  }
+
+  condition {
+    dynamic "http_header" {
+      for_each = var.listener_http_header_conditions
+
+      content {
+        http_header_name = http_header.value["name"]
+        values           = http_header.value["value"]
+      }
     }
   }
 }
@@ -220,6 +253,17 @@ resource "aws_lb_listener_rule" "unauthenticated_hosts_paths" {
   condition {
     path_pattern {
       values = var.unauthenticated_paths
+    }
+  }
+
+  condition {
+    dynamic "http_header" {
+      for_each = var.listener_http_header_conditions
+
+      content {
+        http_header_name = http_header.value["name"]
+        values           = http_header.value["value"]
+      }
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,12 +23,12 @@ variable "unauthenticated_listener_arns_count" {
 }
 
 variable "listener_http_header_conditions" {
-  type        = list(object({
-    name = string
+  type = list(object({
+    name  = string
     value = list(string)
   }))
   default     = []
-  description = "A list of http header conditions to put on the listener."
+  description = "A list of http header conditions to apply to the listener."
 }
 
 variable "authenticated_listener_arns" {

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,15 @@ variable "unauthenticated_listener_arns_count" {
   description = "The number of unauthenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
 }
 
+variable "listener_http_header_conditions" {
+  type        = list(object({
+    name = string
+    value = list(string)
+  }))
+  default     = []
+  description = "A list of http header conditions to put on the listener."
+}
+
 variable "authenticated_listener_arns" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
## what
* Adding an optional http header condition to add to the ALB listener.

## why
* The ability to add an http_header condition to a listener is desired in some cases. This will enable that ability.

