### PR TITLE
Add load balacing algorithm type

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Available targets:
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | listener\_http\_header\_conditions | A list of http header conditions to apply to the listener. | <pre>list(object({<br>    name  = string<br>    value = list(string)<br>  }))</pre> | `[]` | no |
+| load\_balancing\_algorithm\_type | Determines how the load balancer selects targets when routing requests. Only applicable for Application Load Balancer Target Groups. The value is round\_robin or least\_outstanding\_requests. The default is round\_robin. | `string` | `"round_robin"` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | port | The port for the created ALB target group (if `target_group_arn` is not set) | `number` | `80` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -56,6 +56,7 @@
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | listener\_http\_header\_conditions | A list of http header conditions to apply to the listener. | <pre>list(object({<br>    name  = string<br>    value = list(string)<br>  }))</pre> | `[]` | no |
+| load\_balancing\_algorithm\_type | Determines how the load balancer selects targets when routing requests. Only applicable for Application Load Balancer Target Groups. The value is round\_robin or least\_outstanding\_requests. The default is round\_robin. | `string` | `"round_robin"` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | port | The port for the created ALB target group (if `target_group_arn` is not set) | `number` | `80` | no |

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,8 @@ resource "aws_lb_target_group" "default" {
 
   deregistration_delay = var.deregistration_delay
 
+  load_balancing_algorithm_type = var.load_balancing_algorithm_type
+
   stickiness {
     type            = var.stickiness_type
     cookie_duration = var.stickiness_cookie_duration

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "deregistration_delay" {
 }
 
 variable "load_balancing_algorithm_type" {
-  type        = "string"
+  type        = string
   default     = "round_robin"
   description = "Determines how the load balancer selects targets when routing requests. Only applicable for Application Load Balancer Target Groups. The value is round_robin or least_outstanding_requests. The default is round_robin."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable "deregistration_delay" {
   description = "The amount of time to wait in seconds while deregistering target"
 }
 
+variable "load_balancing_algorithm_type" {
+  type        = "string"
+  default     = "round_robin"
+  description = "Determines how the load balancer selects targets when routing requests. Only applicable for Application Load Balancer Target Groups. The value is round_robin or least_outstanding_requests. The default is round_robin."
+}
+
 variable "health_check_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what
* Expose the target group [load_balancing_algorithm_type][load_balancing_algorithm_type] configuration as a variable.

## why
* I would like to change from the default `round_robin` to `least_outstanding_requests`.


[load_balancing_algorithm_type]: 
 https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#load_balancing_algorithm_type