### PR TITLE
Fix HCL spacing in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,89 +101,89 @@ For a complete example, see [examples/complete](examples/complete).
 For automated test of the complete example using `bats` and `Terratest`, see [test](test).
 
 ```hcl
-  provider "aws" {
-    region = var.region
-  }
+provider "aws" {
+  region = var.region
+}
 
-  module "vpc" {
-    source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
-    namespace  = var.namespace
-    stage      = var.stage
-    name       = var.name
-    delimiter  = var.delimiter
-    attributes = var.attributes
-    cidr_block = var.vpc_cidr_block
-    tags       = var.tags
-  }
+module "vpc" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  cidr_block = var.vpc_cidr_block
+  tags       = var.tags
+}
 
-  module "subnets" {
-    source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
-    availability_zones   = var.availability_zones
-    namespace            = var.namespace
-    stage                = var.stage
-    name                 = var.name
-    attributes           = var.attributes
-    delimiter            = var.delimiter
-    vpc_id               = module.vpc.vpc_id
-    igw_id               = module.vpc.igw_id
-    cidr_block           = module.vpc.vpc_cidr_block
-    nat_gateway_enabled  = false
-    nat_instance_enabled = false
-    tags                 = var.tags
-  }
+module "subnets" {
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
+  availability_zones   = var.availability_zones
+  namespace            = var.namespace
+  stage                = var.stage
+  name                 = var.name
+  attributes           = var.attributes
+  delimiter            = var.delimiter
+  vpc_id               = module.vpc.vpc_id
+  igw_id               = module.vpc.igw_id
+  cidr_block           = module.vpc.vpc_cidr_block
+  nat_gateway_enabled  = false
+  nat_instance_enabled = false
+  tags                 = var.tags
+}
 
-  module "alb" {
-    source                                  = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.7.0"
-    namespace                               = var.namespace
-    stage                                   = var.stage
-    name                                    = var.name
-    attributes                              = var.attributes
-    delimiter                               = var.delimiter
-    vpc_id                                  = module.vpc.vpc_id
-    security_group_ids                      = [module.vpc.vpc_default_security_group_id]
-    subnet_ids                              = module.subnets.public_subnet_ids
-    internal                                = var.internal
-    http_enabled                            = var.http_enabled
-    access_logs_enabled                     = var.access_logs_enabled
-    alb_access_logs_s3_bucket_force_destroy = var.alb_access_logs_s3_bucket_force_destroy
-    cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
-    http2_enabled                           = var.http2_enabled
-    idle_timeout                            = var.idle_timeout
-    ip_address_type                         = var.ip_address_type
-    deletion_protection_enabled             = var.deletion_protection_enabled
-    deregistration_delay                    = var.deregistration_delay
-    health_check_path                       = var.health_check_path
-    health_check_timeout                    = var.health_check_timeout
-    health_check_healthy_threshold          = var.health_check_healthy_threshold
-    health_check_unhealthy_threshold        = var.health_check_unhealthy_threshold
-    health_check_interval                   = var.health_check_interval
-    health_check_matcher                    = var.health_check_matcher
-    target_group_port                       = var.target_group_port
-    target_group_target_type                = var.target_group_target_type
-    tags                                    = var.tags
-  }
+module "alb" {
+  source                                  = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.7.0"
+  namespace                               = var.namespace
+  stage                                   = var.stage
+  name                                    = var.name
+  attributes                              = var.attributes
+  delimiter                               = var.delimiter
+  vpc_id                                  = module.vpc.vpc_id
+  security_group_ids                      = [module.vpc.vpc_default_security_group_id]
+  subnet_ids                              = module.subnets.public_subnet_ids
+  internal                                = var.internal
+  http_enabled                            = var.http_enabled
+  access_logs_enabled                     = var.access_logs_enabled
+  alb_access_logs_s3_bucket_force_destroy = var.alb_access_logs_s3_bucket_force_destroy
+  cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
+  http2_enabled                           = var.http2_enabled
+  idle_timeout                            = var.idle_timeout
+  ip_address_type                         = var.ip_address_type
+  deletion_protection_enabled             = var.deletion_protection_enabled
+  deregistration_delay                    = var.deregistration_delay
+  health_check_path                       = var.health_check_path
+  health_check_timeout                    = var.health_check_timeout
+  health_check_healthy_threshold          = var.health_check_healthy_threshold
+  health_check_unhealthy_threshold        = var.health_check_unhealthy_threshold
+  health_check_interval                   = var.health_check_interval
+  health_check_matcher                    = var.health_check_matcher
+  target_group_port                       = var.target_group_port
+  target_group_target_type                = var.target_group_target_type
+  tags                                    = var.tags
+}
 
-  module "alb_ingress" {
-    source = "cloudposse/alb-ingress/aws"
-    # Cloud Posse recommends pinning every module to a specific version
-    # version     = "x.x.x"
-    namespace                           = var.namespace
-    stage                               = var.stage
-    name                                = var.name
-    attributes                          = var.attributes
-    delimiter                           = var.delimiter
-    vpc_id                              = module.vpc.vpc_id
-    authentication_type                 = var.authentication_type
-    unauthenticated_priority            = var.unauthenticated_priority
-    unauthenticated_paths               = var.unauthenticated_paths
-    slow_start                          = var.slow_start
-    stickiness_enabled                  = var.stickiness_enabled
-    default_target_group_enabled        = false
-    target_group_arn                    = module.alb.default_target_group_arn
-    unauthenticated_listener_arns       = [module.alb.http_listener_arn]
-    unauthenticated_listener_arns_count = 1
-    tags                                = var.tags
-  }
+module "alb_ingress" {
+  source = "cloudposse/alb-ingress/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+  namespace                           = var.namespace
+  stage                               = var.stage
+  name                                = var.name
+  attributes                          = var.attributes
+  delimiter                           = var.delimiter
+  vpc_id                              = module.vpc.vpc_id
+  authentication_type                 = var.authentication_type
+  unauthenticated_priority            = var.unauthenticated_priority
+  unauthenticated_paths               = var.unauthenticated_paths
+  slow_start                          = var.slow_start
+  stickiness_enabled                  = var.stickiness_enabled
+  default_target_group_enabled        = false
+  target_group_arn                    = module.alb.default_target_group_arn
+  unauthenticated_listener_arns       = [module.alb.http_listener_arn]
+  unauthenticated_listener_arns_count = 1
+  tags                                = var.tags
+}
 ```
 
 
@@ -219,6 +219,20 @@ Available targets:
 | Name | Version |
 |------|---------|
 | aws | >= 2.42 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_lb_listener_rule](https://registry.terraform.io/providers/hashicorp/aws/2.42/docs/resources/lb_listener_rule) |
+| [aws_lb_target_group](https://registry.terraform.io/providers/hashicorp/aws/2.42/docs/data-sources/lb_target_group) |
+| [aws_lb_target_group](https://registry.terraform.io/providers/hashicorp/aws/2.42/docs/resources/lb_target_group) |
 
 ## Inputs
 
@@ -291,7 +305,6 @@ Available targets:
 | target\_group\_arn | ALB Target Group ARN |
 | target\_group\_arn\_suffix | ALB Target Group ARN suffix |
 | target\_group\_name | ALB Target Group name |
-
 <!-- markdownlint-restore -->
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -23,89 +23,89 @@ usage: |-
   For automated test of the complete example using `bats` and `Terratest`, see [test](test).
 
   ```hcl
-    provider "aws" {
-      region = var.region
-    }
+  provider "aws" {
+    region = var.region
+  }
 
-    module "vpc" {
-      source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
-      namespace  = var.namespace
-      stage      = var.stage
-      name       = var.name
-      delimiter  = var.delimiter
-      attributes = var.attributes
-      cidr_block = var.vpc_cidr_block
-      tags       = var.tags
-    }
+  module "vpc" {
+    source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+    namespace  = var.namespace
+    stage      = var.stage
+    name       = var.name
+    delimiter  = var.delimiter
+    attributes = var.attributes
+    cidr_block = var.vpc_cidr_block
+    tags       = var.tags
+  }
 
-    module "subnets" {
-      source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
-      availability_zones   = var.availability_zones
-      namespace            = var.namespace
-      stage                = var.stage
-      name                 = var.name
-      attributes           = var.attributes
-      delimiter            = var.delimiter
-      vpc_id               = module.vpc.vpc_id
-      igw_id               = module.vpc.igw_id
-      cidr_block           = module.vpc.vpc_cidr_block
-      nat_gateway_enabled  = false
-      nat_instance_enabled = false
-      tags                 = var.tags
-    }
+  module "subnets" {
+    source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
+    availability_zones   = var.availability_zones
+    namespace            = var.namespace
+    stage                = var.stage
+    name                 = var.name
+    attributes           = var.attributes
+    delimiter            = var.delimiter
+    vpc_id               = module.vpc.vpc_id
+    igw_id               = module.vpc.igw_id
+    cidr_block           = module.vpc.vpc_cidr_block
+    nat_gateway_enabled  = false
+    nat_instance_enabled = false
+    tags                 = var.tags
+  }
 
-    module "alb" {
-      source                                  = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.7.0"
-      namespace                               = var.namespace
-      stage                                   = var.stage
-      name                                    = var.name
-      attributes                              = var.attributes
-      delimiter                               = var.delimiter
-      vpc_id                                  = module.vpc.vpc_id
-      security_group_ids                      = [module.vpc.vpc_default_security_group_id]
-      subnet_ids                              = module.subnets.public_subnet_ids
-      internal                                = var.internal
-      http_enabled                            = var.http_enabled
-      access_logs_enabled                     = var.access_logs_enabled
-      alb_access_logs_s3_bucket_force_destroy = var.alb_access_logs_s3_bucket_force_destroy
-      cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
-      http2_enabled                           = var.http2_enabled
-      idle_timeout                            = var.idle_timeout
-      ip_address_type                         = var.ip_address_type
-      deletion_protection_enabled             = var.deletion_protection_enabled
-      deregistration_delay                    = var.deregistration_delay
-      health_check_path                       = var.health_check_path
-      health_check_timeout                    = var.health_check_timeout
-      health_check_healthy_threshold          = var.health_check_healthy_threshold
-      health_check_unhealthy_threshold        = var.health_check_unhealthy_threshold
-      health_check_interval                   = var.health_check_interval
-      health_check_matcher                    = var.health_check_matcher
-      target_group_port                       = var.target_group_port
-      target_group_target_type                = var.target_group_target_type
-      tags                                    = var.tags
-    }
+  module "alb" {
+    source                                  = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.7.0"
+    namespace                               = var.namespace
+    stage                                   = var.stage
+    name                                    = var.name
+    attributes                              = var.attributes
+    delimiter                               = var.delimiter
+    vpc_id                                  = module.vpc.vpc_id
+    security_group_ids                      = [module.vpc.vpc_default_security_group_id]
+    subnet_ids                              = module.subnets.public_subnet_ids
+    internal                                = var.internal
+    http_enabled                            = var.http_enabled
+    access_logs_enabled                     = var.access_logs_enabled
+    alb_access_logs_s3_bucket_force_destroy = var.alb_access_logs_s3_bucket_force_destroy
+    cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
+    http2_enabled                           = var.http2_enabled
+    idle_timeout                            = var.idle_timeout
+    ip_address_type                         = var.ip_address_type
+    deletion_protection_enabled             = var.deletion_protection_enabled
+    deregistration_delay                    = var.deregistration_delay
+    health_check_path                       = var.health_check_path
+    health_check_timeout                    = var.health_check_timeout
+    health_check_healthy_threshold          = var.health_check_healthy_threshold
+    health_check_unhealthy_threshold        = var.health_check_unhealthy_threshold
+    health_check_interval                   = var.health_check_interval
+    health_check_matcher                    = var.health_check_matcher
+    target_group_port                       = var.target_group_port
+    target_group_target_type                = var.target_group_target_type
+    tags                                    = var.tags
+  }
 
-    module "alb_ingress" {
-      source = "cloudposse/alb-ingress/aws"
-      # Cloud Posse recommends pinning every module to a specific version
-      # version     = "x.x.x"
-      namespace                           = var.namespace
-      stage                               = var.stage
-      name                                = var.name
-      attributes                          = var.attributes
-      delimiter                           = var.delimiter
-      vpc_id                              = module.vpc.vpc_id
-      authentication_type                 = var.authentication_type
-      unauthenticated_priority            = var.unauthenticated_priority
-      unauthenticated_paths               = var.unauthenticated_paths
-      slow_start                          = var.slow_start
-      stickiness_enabled                  = var.stickiness_enabled
-      default_target_group_enabled        = false
-      target_group_arn                    = module.alb.default_target_group_arn
-      unauthenticated_listener_arns       = [module.alb.http_listener_arn]
-      unauthenticated_listener_arns_count = 1
-      tags                                = var.tags
-    }
+  module "alb_ingress" {
+    source = "cloudposse/alb-ingress/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
+    namespace                           = var.namespace
+    stage                               = var.stage
+    name                                = var.name
+    attributes                          = var.attributes
+    delimiter                           = var.delimiter
+    vpc_id                              = module.vpc.vpc_id
+    authentication_type                 = var.authentication_type
+    unauthenticated_priority            = var.unauthenticated_priority
+    unauthenticated_paths               = var.unauthenticated_paths
+    slow_start                          = var.slow_start
+    stickiness_enabled                  = var.stickiness_enabled
+    default_target_group_enabled        = false
+    target_group_arn                    = module.alb.default_target_group_arn
+    unauthenticated_listener_arns       = [module.alb.http_listener_arn]
+    unauthenticated_listener_arns_count = 1
+    tags                                = var.tags
+  }
   ```
 include:
 - docs/targets.md

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,6 +15,20 @@
 |------|---------|
 | aws | >= 2.42 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_lb_listener_rule](https://registry.terraform.io/providers/hashicorp/aws/2.42/docs/resources/lb_listener_rule) |
+| [aws_lb_target_group](https://registry.terraform.io/providers/hashicorp/aws/2.42/docs/data-sources/lb_target_group) |
+| [aws_lb_target_group](https://registry.terraform.io/providers/hashicorp/aws/2.42/docs/resources/lb_target_group) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -86,5 +100,4 @@
 | target\_group\_arn | ALB Target Group ARN |
 | target\_group\_arn\_suffix | ALB Target Group ARN suffix |
 | target\_group\_name | ALB Target Group name |
-
 <!-- markdownlint-restore -->


### PR DESCRIPTION
## what
Fixed the HCL spacing in the `README.md` example

## why
Because it was annoying to fix the spacing when copying and pasting

## references
N/A

