### PR TITLE
Remove _count vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ module "alb_ingress" {
   default_target_group_enabled        = false
   target_group_arn                    = module.alb.default_target_group_arn
   unauthenticated_listener_arns       = [module.alb.http_listener_arn]
-  unauthenticated_listener_arns_count = 1
   tags                                = var.tags
 }
 ```
@@ -242,7 +241,6 @@ Available targets:
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | authenticated\_hosts | Authenticated hosts to match in Hosts header | `list(string)` | `[]` | no |
 | authenticated\_listener\_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | `list(string)` | `[]` | no |
-| authenticated\_listener\_arns\_count | The number of authenticated ARNs in `authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
 | authenticated\_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | `list(string)` | `[]` | no |
 | authenticated\_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `unauthenticated_priority` since a listener can't have multiple rules with the same priority | `number` | `0` | no |
 | authentication\_cognito\_scope | Cognito scope | `list(string)` | `[]` | no |
@@ -293,7 +291,6 @@ Available targets:
 | target\_type | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the target group | `string` | `"ip"` | no |
 | unauthenticated\_hosts | Unauthenticated hosts to match in Hosts header | `list(string)` | `[]` | no |
 | unauthenticated\_listener\_arns | A list of unauthenticated ALB listener ARNs to attach ALB listener rules to | `list(string)` | `[]` | no |
-| unauthenticated\_listener\_arns\_count | The number of unauthenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
 | unauthenticated\_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | `list(string)` | `[]` | no |
 | unauthenticated\_priority | The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `authenticated_priority` since a listener can't have multiple rules with the same priority | `number` | `0` | no |
 | vpc\_id | The VPC ID where generated ALB target group will be provisioned (if `target_group_arn` is not set) | `string` | n/a | yes |

--- a/README.yaml
+++ b/README.yaml
@@ -103,7 +103,6 @@ usage: |-
     default_target_group_enabled        = false
     target_group_arn                    = module.alb.default_target_group_arn
     unauthenticated_listener_arns       = [module.alb.http_listener_arn]
-    unauthenticated_listener_arns_count = 1
     tags                                = var.tags
   }
   ```

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -37,7 +37,6 @@
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | authenticated\_hosts | Authenticated hosts to match in Hosts header | `list(string)` | `[]` | no |
 | authenticated\_listener\_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | `list(string)` | `[]` | no |
-| authenticated\_listener\_arns\_count | The number of authenticated ARNs in `authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
 | authenticated\_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | `list(string)` | `[]` | no |
 | authenticated\_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `unauthenticated_priority` since a listener can't have multiple rules with the same priority | `number` | `0` | no |
 | authentication\_cognito\_scope | Cognito scope | `list(string)` | `[]` | no |
@@ -88,7 +87,6 @@
 | target\_type | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the target group | `string` | `"ip"` | no |
 | unauthenticated\_hosts | Unauthenticated hosts to match in Hosts header | `list(string)` | `[]` | no |
 | unauthenticated\_listener\_arns | A list of unauthenticated ALB listener ARNs to attach ALB listener rules to | `list(string)` | `[]` | no |
-| unauthenticated\_listener\_arns\_count | The number of unauthenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
 | unauthenticated\_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | `list(string)` | `[]` | no |
 | unauthenticated\_priority | The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `authenticated_priority` since a listener can't have multiple rules with the same priority | `number` | `0` | no |
 | vpc\_id | The VPC ID where generated ALB target group will be provisioned (if `target_group_arn` is not set) | `string` | n/a | yes |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -57,15 +57,15 @@ module "alb" {
 module "alb_ingress" {
   source = "../.."
 
-  vpc_id                              = module.vpc.vpc_id
-  authentication_type                 = var.authentication_type
-  unauthenticated_priority            = var.unauthenticated_priority
-  unauthenticated_paths               = var.unauthenticated_paths
-  slow_start                          = var.slow_start
-  stickiness_enabled                  = var.stickiness_enabled
-  default_target_group_enabled        = false
-  target_group_arn                    = module.alb.default_target_group_arn
-  unauthenticated_listener_arns       = [module.alb.http_listener_arn]
+  vpc_id                        = module.vpc.vpc_id
+  authentication_type           = var.authentication_type
+  unauthenticated_priority      = var.unauthenticated_priority
+  unauthenticated_paths         = var.unauthenticated_paths
+  slow_start                    = var.slow_start
+  stickiness_enabled            = var.stickiness_enabled
+  default_target_group_enabled  = false
+  target_group_arn              = module.alb.default_target_group_arn
+  unauthenticated_listener_arns = [module.alb.http_listener_arn]
 
   context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -66,7 +66,6 @@ module "alb_ingress" {
   default_target_group_enabled        = false
   target_group_arn                    = module.alb.default_target_group_arn
   unauthenticated_listener_arns       = [module.alb.http_listener_arn]
-  unauthenticated_listener_arns_count = 1
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "aws_lb_target_group" "default" {
 }
 
 resource "aws_lb_listener_rule" "unauthenticated_paths" {
-  count = module.this.enabled && length(var.unauthenticated_paths) > 0 && length(var.unauthenticated_hosts) == 0 ? var.unauthenticated_listener_arns_count : 0
+  count = module.this.enabled && length(var.unauthenticated_paths) > 0 && length(var.unauthenticated_hosts) == 0 ? length(var.unauthenticated_listener_arns) : 0
 
   listener_arn = var.unauthenticated_listener_arns[count.index]
   priority     = var.unauthenticated_priority > 0 ? var.unauthenticated_priority + count.index : null
@@ -77,7 +77,7 @@ resource "aws_lb_listener_rule" "unauthenticated_paths" {
 }
 
 resource "aws_lb_listener_rule" "authenticated_paths_oidc" {
-  count = module.this.enabled && var.authentication_type == "OIDC" && length(var.authenticated_paths) > 0 && length(var.authenticated_hosts) == 0 ? var.authenticated_listener_arns_count : 0
+  count = module.this.enabled && var.authentication_type == "OIDC" && length(var.authenticated_paths) > 0 && length(var.authenticated_hosts) == 0 ? length(var.authenticated_listener_arns) : 0
 
   listener_arn = var.authenticated_listener_arns[count.index]
   priority     = var.authenticated_priority > 0 ? var.authenticated_priority + count.index : null
@@ -123,7 +123,7 @@ resource "aws_lb_listener_rule" "authenticated_paths_oidc" {
 }
 
 resource "aws_lb_listener_rule" "authenticated_paths_cognito" {
-  count = module.this.enabled && var.authentication_type == "COGNITO" && length(var.authenticated_paths) > 0 && length(var.authenticated_hosts) == 0 ? var.authenticated_listener_arns_count : 0
+  count = module.this.enabled && var.authentication_type == "COGNITO" && length(var.authenticated_paths) > 0 && length(var.authenticated_hosts) == 0 ? length(var.authenticated_listener_arns) : 0
 
   listener_arn = var.authenticated_listener_arns[count.index]
   priority     = var.authenticated_priority > 0 ? var.authenticated_priority + count.index : null
@@ -166,7 +166,7 @@ resource "aws_lb_listener_rule" "authenticated_paths_cognito" {
 }
 
 resource "aws_lb_listener_rule" "unauthenticated_hosts" {
-  count = module.this.enabled && length(var.unauthenticated_hosts) > 0 && length(var.unauthenticated_paths) == 0 ? var.unauthenticated_listener_arns_count : 0
+  count = module.this.enabled && length(var.unauthenticated_hosts) > 0 && length(var.unauthenticated_paths) == 0 ? length(var.unauthenticated_listener_arns) : 0
 
   listener_arn = var.unauthenticated_listener_arns[count.index]
   priority     = var.unauthenticated_priority > 0 ? var.unauthenticated_priority + count.index : null
@@ -184,7 +184,7 @@ resource "aws_lb_listener_rule" "unauthenticated_hosts" {
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_oidc" {
-  count = module.this.enabled && var.authentication_type == "OIDC" && length(var.authenticated_hosts) > 0 && length(var.authenticated_paths) == 0 ? var.authenticated_listener_arns_count : 0
+  count = module.this.enabled && var.authentication_type == "OIDC" && length(var.authenticated_hosts) > 0 && length(var.authenticated_paths) == 0 ? length(var.authenticated_listener_arns) : 0
 
   listener_arn = var.authenticated_listener_arns[count.index]
   priority     = var.authenticated_priority > 0 ? var.authenticated_priority + count.index : null
@@ -216,7 +216,7 @@ resource "aws_lb_listener_rule" "authenticated_hosts_oidc" {
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_cognito" {
-  count = module.this.enabled && var.authentication_type == "COGNITO" && length(var.authenticated_hosts) > 0 && length(var.authenticated_paths) == 0 ? var.authenticated_listener_arns_count : 0
+  count = module.this.enabled && var.authentication_type == "COGNITO" && length(var.authenticated_hosts) > 0 && length(var.authenticated_paths) == 0 ? length(var.authenticated_listener_arns) : 0
 
   listener_arn = var.authenticated_listener_arns[count.index]
   priority     = var.authenticated_priority > 0 ? var.authenticated_priority + count.index : null
@@ -245,7 +245,7 @@ resource "aws_lb_listener_rule" "authenticated_hosts_cognito" {
 }
 
 resource "aws_lb_listener_rule" "unauthenticated_hosts_paths" {
-  count = module.this.enabled && length(var.unauthenticated_paths) > 0 && length(var.unauthenticated_hosts) > 0 ? var.unauthenticated_listener_arns_count : 0
+  count = module.this.enabled && length(var.unauthenticated_paths) > 0 && length(var.unauthenticated_hosts) > 0 ? length(var.unauthenticated_listener_arns) : 0
 
   listener_arn = var.unauthenticated_listener_arns[count.index]
   priority     = var.unauthenticated_priority > 0 ? var.unauthenticated_priority + count.index : null
@@ -283,7 +283,7 @@ resource "aws_lb_listener_rule" "unauthenticated_hosts_paths" {
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_paths_oidc" {
-  count = module.this.enabled && var.authentication_type == "OIDC" && length(var.authenticated_paths) > 0 && length(var.authenticated_hosts) > 0 ? var.authenticated_listener_arns_count : 0
+  count = module.this.enabled && var.authentication_type == "OIDC" && length(var.authenticated_paths) > 0 && length(var.authenticated_hosts) > 0 ? length(var.authenticated_listener_arns) : 0
 
   listener_arn = var.authenticated_listener_arns[count.index]
   priority     = var.authenticated_priority > 0 ? var.authenticated_priority + count.index : null
@@ -321,7 +321,7 @@ resource "aws_lb_listener_rule" "authenticated_hosts_paths_oidc" {
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_paths_cognito" {
-  count = module.this.enabled && var.authentication_type == "COGNITO" && length(var.authenticated_paths) > 0 && length(var.authenticated_hosts) > 0 ? var.authenticated_listener_arns_count : 0
+  count = module.this.enabled && var.authentication_type == "COGNITO" && length(var.authenticated_paths) > 0 && length(var.authenticated_hosts) > 0 ? length(var.authenticated_listener_arns) : 0
 
   listener_arn = var.authenticated_listener_arns[count.index]
   priority     = var.authenticated_priority > 0 ? var.authenticated_priority + count.index : null

--- a/variables.tf
+++ b/variables.tf
@@ -16,12 +16,6 @@ variable "unauthenticated_listener_arns" {
   description = "A list of unauthenticated ALB listener ARNs to attach ALB listener rules to"
 }
 
-variable "unauthenticated_listener_arns_count" {
-  type        = number
-  default     = 0
-  description = "The number of unauthenticated ARNs in `unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
-}
-
 variable "listener_http_header_conditions" {
   type = list(object({
     name  = string
@@ -35,12 +29,6 @@ variable "authenticated_listener_arns" {
   type        = list(string)
   default     = []
   description = "A list of authenticated ALB listener ARNs to attach ALB listener rules to"
-}
-
-variable "authenticated_listener_arns_count" {
-  type        = number
-  default     = 0
-  description = "The number of authenticated ARNs in `authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
 }
 
 variable "deregistration_delay" {


### PR DESCRIPTION
## what
* Remove `var.unauthenticated_listener_arns_count` and `var.authenticated_listener_arns_count` variables

## why
* These variables were a workaround for limitations in old versions of terraform from two years ago. The newer versions in 0.14.x no longer require these variables.

## references
N/A

