### PR TITLE
Add create_before_destroy lifecycle to target group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,10 @@ resource "aws_lb_target_group" "default" {
     interval            = var.health_check_interval
     matcher             = var.health_check_matcher
   }
+    
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_lb_listener_rule" "unauthenticated_paths" {

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_lb_target_group" "default" {
     interval            = var.health_check_interval
     matcher             = var.health_check_matcher
   }
-    
+
   lifecycle {
     create_before_destroy = true
   }


### PR DESCRIPTION
## what
* Add create_before_destroy lifecycle to target group

## why
* Prevent `ResourceInUse` error with the target group when making changes

## references
* Closes https://github.com/cloudposse/terraform-aws-alb-ingress/issues/24

