### PR TITLE
Add listener_http_header_conditions to the resources where it is missing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -189,6 +189,20 @@ resource "aws_lb_listener_rule" "unauthenticated_hosts" {
       values = var.unauthenticated_hosts
     }
   }
+
+  dynamic "condition" {
+    for_each = length(var.listener_http_header_conditions) > 0 ? [""] : []
+    content {
+      dynamic "http_header" {
+        for_each = var.listener_http_header_conditions
+
+        content {
+          http_header_name = http_header.value["name"]
+          values           = http_header.value["value"]
+        }
+      }
+    }
+  }
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_oidc" {
@@ -224,6 +238,20 @@ resource "aws_lb_listener_rule" "authenticated_hosts_oidc" {
       values = var.authenticated_hosts
     }
   }
+
+  dynamic "condition" {
+    for_each = length(var.listener_http_header_conditions) > 0 ? [""] : []
+    content {
+      dynamic "http_header" {
+        for_each = var.listener_http_header_conditions
+
+        content {
+          http_header_name = http_header.value["name"]
+          values           = http_header.value["value"]
+        }
+      }
+    }
+  }
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_cognito" {
@@ -254,6 +282,20 @@ resource "aws_lb_listener_rule" "authenticated_hosts_cognito" {
   condition {
     host_header {
       values = var.authenticated_hosts
+    }
+  }
+
+  dynamic "condition" {
+    for_each = length(var.listener_http_header_conditions) > 0 ? [""] : []
+    content {
+      dynamic "http_header" {
+        for_each = var.listener_http_header_conditions
+
+        content {
+          http_header_name = http_header.value["name"]
+          values           = http_header.value["value"]
+        }
+      }
     }
   }
 }
@@ -335,6 +377,20 @@ resource "aws_lb_listener_rule" "authenticated_hosts_paths_oidc" {
       values = var.authenticated_paths
     }
   }
+
+  dynamic "condition" {
+    for_each = length(var.listener_http_header_conditions) > 0 ? [""] : []
+    content {
+      dynamic "http_header" {
+        for_each = var.listener_http_header_conditions
+
+        content {
+          http_header_name = http_header.value["name"]
+          values           = http_header.value["value"]
+        }
+      }
+    }
+  }
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_paths_cognito" {
@@ -371,6 +427,20 @@ resource "aws_lb_listener_rule" "authenticated_hosts_paths_cognito" {
   condition {
     path_pattern {
       values = var.authenticated_paths
+    }
+  }
+
+  dynamic "condition" {
+    for_each = length(var.listener_http_header_conditions) > 0 ? [""] : []
+    content {
+      dynamic "http_header" {
+        for_each = var.listener_http_header_conditions
+
+        content {
+          http_header_name = http_header.value["name"]
+          values           = http_header.value["value"]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## what
* This PR gives ability to define `listener_http_header_conditions` for all types of listeners created by this module.

## why
* We have discovered that we are unable to have that option when we are using `hosts` conditions. No matter if it is authenticated or unauthenticated hosts.
* In my opinion this option should be avaliable for all types of checks. 

