### PR TITLE
Feature/remove template provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ Available targets:
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.42 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,7 +7,6 @@
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.42 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
     null = {
       source  = "hashicorp/null"
       version = ">= 2.0"

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.42"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
     null = {
       source  = "hashicorp/null"
       version = ">= 2.0"


### PR DESCRIPTION
## what
* Remove unused and deprecated template provider 

## why
* hashicorp/template is now deprecated
* hashicorp/template has not been compiled and shared for M1 processors (Macbook Air M1, Macbook Pro, ...)
* template provider is not used in this module...

## references
* see: [https://registry.terraform.io/providers/hashicorp/template/latest/docs]()