### PR TITLE
Use context tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,6 @@ resource "aws_lb_target_group" "default" {
   protocol         = var.protocol
   protocol_version = var.protocol_version
   slow_start       = var.slow_start
-  tags             = var.tags
   target_type      = var.target_type
   vpc_id           = var.vpc_id
 
@@ -41,6 +40,8 @@ resource "aws_lb_target_group" "default" {
     interval            = var.health_check_interval
     matcher             = var.health_check_matcher
   }
+
+  tags = module.this.tags
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## what
* Use context tags

## why
* This way we can pass in the `context` to tag the resource instead of having to supply the `tags` in manually. The `tags` are already passed into the `context` inputs.

## references
N/A
