### PR TITLE
feat: add tags to Listener Rules

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -11,7 +11,7 @@ module "vpc" {
 
 module "subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "2.3.0"
+  version              = "2.4.2"
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
   igw_id               = [module.vpc.igw_id]

--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,8 @@ resource "aws_lb_listener_rule" "unauthenticated_paths" {
       }
     }
   }
+
+  tags = module.this.tags
 }
 
 resource "aws_lb_listener_rule" "authenticated_paths_oidc" {
@@ -136,6 +138,8 @@ resource "aws_lb_listener_rule" "authenticated_paths_oidc" {
       }
     }
   }
+
+  tags = module.this.tags
 }
 
 resource "aws_lb_listener_rule" "authenticated_paths_cognito" {
@@ -182,6 +186,8 @@ resource "aws_lb_listener_rule" "authenticated_paths_cognito" {
       }
     }
   }
+
+  tags = module.this.tags
 }
 
 resource "aws_lb_listener_rule" "unauthenticated_hosts" {
@@ -214,6 +220,8 @@ resource "aws_lb_listener_rule" "unauthenticated_hosts" {
       }
     }
   }
+
+  tags = module.this.tags
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_oidc" {
@@ -263,6 +271,8 @@ resource "aws_lb_listener_rule" "authenticated_hosts_oidc" {
       }
     }
   }
+
+  tags = module.this.tags
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_cognito" {
@@ -309,6 +319,8 @@ resource "aws_lb_listener_rule" "authenticated_hosts_cognito" {
       }
     }
   }
+
+  tags = module.this.tags
 }
 
 resource "aws_lb_listener_rule" "unauthenticated_hosts_paths" {
@@ -347,6 +359,8 @@ resource "aws_lb_listener_rule" "unauthenticated_hosts_paths" {
       }
     }
   }
+
+  tags = module.this.tags
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_paths_oidc" {
@@ -402,6 +416,8 @@ resource "aws_lb_listener_rule" "authenticated_hosts_paths_oidc" {
       }
     }
   }
+
+  tags = module.this.tags
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_paths_cognito" {
@@ -454,4 +470,6 @@ resource "aws_lb_listener_rule" "authenticated_hosts_paths_cognito" {
       }
     }
   }
+
+  tags = module.this.tags
 }


### PR DESCRIPTION
Add tags from the context to the listener rules.

This module provisions a target group (already has tag applied using the context), and listener rules (which are missing the tags).

Why tags? For visibility, both within the resource itself on AWS, and on the ALB listener level. And of course, tagging is best practices (organizations who enforce tags will fail that check without this).

See before and after:

<img width="1300" height="547" alt="image" src="https://github.com/user-attachments/assets/6701bf96-c740-4f73-b3f0-27a1bd2e1a2c" />
<img width="1346" height="583" alt="image" src="https://github.com/user-attachments/assets/897b79fe-29b2-4990-b97d-ad377c6a7b27" />

